### PR TITLE
Fix

### DIFF
--- a/backend/app/api/v1/endpoints/prediction.py
+++ b/backend/app/api/v1/endpoints/prediction.py
@@ -13,7 +13,7 @@ from datascience.classification import get_prediction
 router = APIRouter()
 
 
-@router.post("/prediction", response_model=List[schemas.PredictionResult])
+@router.post("/", response_model=List[schemas.PredictionResult])
 async def predict_category(
     *,
     _db: Session = Depends(deps.get_db),

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -77,10 +77,11 @@ def read_user_me(
     """
     return current_user
 
+
 @router.get("/{user_id}", response_model=schemas.User)
 def read_user_by_id(
     user_id: int,
-    current_user: models.User = Depends(dependencies.get_current_active_user),
+    current_user: models.User = Depends(dependencies.get_current_active_admin),
     db: Session = Depends(dependencies.get_db),
 ) -> Any:
     """
@@ -102,7 +103,7 @@ def update_user(
     db: Session = Depends(dependencies.get_db),
     user_id: int,
     user_in: schemas.UserUpdate,
-    current_user: models.User = Depends(dependencies.get_current_active_admin),
+    _current_user: models.User = Depends(dependencies.get_current_active_admin),
 ) -> Any:
     """
     Update a user.


### PR DESCRIPTION
- Réduit la taille de la route de prédiction.
- Ne permet que aux admins de récupérer les informations des utilisateurs à partir de leur identifiant.