### PR TITLE
backend: fix gitconfig not forwarded to dev container

### DIFF
--- a/backend/.devcontainer/devcontainer.json
+++ b/backend/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	// This can be used to network with other containers or the host.
 	// "forwardPorts": [5000, 5432],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "./start-reload.sh",
+	"postStartCommand": "./start-reload.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
- changed postCreateCommand into postStartCommand

.gitconfig is copied to the container as soon as postCreateCommand is done since our postCreateCommand is infinit, it was never copied.