### PR TITLE
ci: only refresh package cache when poetry.lock changes

### DIFF
--- a/.github/workflows/cache_poetry_packages.yaml
+++ b/.github/workflows/cache_poetry_packages.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/poetry.lock"
 
 jobs:
   project_matrix:


### PR DESCRIPTION
Even though the cache was not refreshed with the previous version, it was still using 2 minutes of computing power for nothing.

Fixes #91