### PR TITLE
chore: add tooling to help developers validate their commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,12 @@ repos:
   - id: check-yaml
     stages: [pre-push]
   - id: check-added-large-files
-- repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v2.4.0
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: "v9.5.0"
   hooks:
-  - id: conventional-pre-commit
-    stages: [commit-msg]
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']
 - repo: local
   hooks:
   - id: codecheck-backend

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        "header-max-length": [2, "always", 72],
+        "body-max-line-length": [2, "always", 100],
+        "references-empty": [2, "never"],
+    }
+}

--- a/e-commerce-mlops.code-workspace
+++ b/e-commerce-mlops.code-workspace
@@ -90,6 +90,14 @@
 		"[jsonc]": {
 			"editor.defaultFormatter": "vscode.json-language-features"
 		},
+		"[git-commit]": {
+			"editor.rulers": [
+				72,
+				100
+			],
+			"workbench.editor.restoreViewState": false,
+			"files.insertFinalNewline": false,
+		},
 		"autoDocstring.docstringFormat": "google-notypes",
 		"sqltools.connections": [
 			{
@@ -112,10 +120,13 @@
 			"main"
 		],
 		"conventionalCommits.scopes": [
-			"all",
 			"backend",
 			"datascience"
 		],
 		"conventionalCommits.autoCommit": false,
+		"git.inputValidationLength": 100,
+		"git.inputValidationSubjectLength": 72,
+		"conventionalCommits.gitmoji": false,
+		"conventionalCommits.showEditor": true,
 	},
 }


### PR DESCRIPTION
conventional-pre-commit hook is replaced by commitlint-pre-commit-hook. Add commitlint.config.js with settings regarding:
- max length for header and body
- presence of an issue's reference in the footer. In addition, the workspace settings are updated to :
- remove emoji from the Conventional Commit extension
- force Conventional Commit extension to open a text file to complete commit message and add ref
- display rulers during commit message edition and warnings in the source control field.

Closes: #93