### PR TITLE
chore: fix Pylance analysing all files including .venv on VSCode

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -66,7 +66,7 @@ opentelemetry-instrumentation-system-metrics = "^0.40b0"
 opentelemetry-instrumentation-tornado = "^0.40b0"
 opentelemetry-instrumentation-tortoiseorm = "^0.40b0"
 opentelemetry-instrumentation-urllib3 = "^0.40b0"
-pydantic = {version = "*", extras = ["dotenv"]}
+pydantic = { version = "*", extras = ["dotenv"] }
 
 
 [tool.poetry.group.dev.dependencies]
@@ -91,20 +91,6 @@ types-six = "*"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.pyright]
-pythonVersion = "3.11"
-typeCheckingMode = "strict"
-include = ["app"]
-exclude = [
-    "**/node_modules",
-    "**/venv",
-    "**/.venv",
-    "**/.pytest_cache",
-    "**/__pycache__",
-    ".ruff_cache",
-    "**/Python.framework/**",
-]
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/datascience/pyproject.toml
+++ b/datascience/pyproject.toml
@@ -33,8 +33,10 @@ tensorflow-metal = { version = "1.0.0", platform = "darwin" }
 tensorflow-intel = { version = "2.13.0", markers = "platform_system=='Windows'" }
 
 mlflow = "^2.6.0"
-pydantic = {version = "*", extras = ["dotenv"]}
+pydantic = { version = "*", extras = ["dotenv"] }
 python-json-logger = "^2.0.7"
+imagesize = "^1.4.1"
+pillow = "^10.0.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.*"
@@ -47,22 +49,6 @@ pytest = "^7.4.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.pyright]
-pythonVersion = "3.11"
-typeCheckingMode = "basic"
-exclude = ["**/.pytest_cache", "**/__pycache__", ".ruff_cache"]
-
-[tool.mypy]
-strict = true
-warn_return_any = false
-implicit_reexport = false
-namespace_packages = true
-plugins = ["numpy.typing.mypy_plugin", "pydantic.mypy"]
-
-[[tool.mypy.overrides]]
-module = "gdown"
-ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/datascience/pyproject.toml
+++ b/datascience/pyproject.toml
@@ -35,8 +35,6 @@ tensorflow-intel = { version = "2.13.0", markers = "platform_system=='Windows'" 
 mlflow = "^2.6.0"
 pydantic = { version = "*", extras = ["dotenv"] }
 python-json-logger = "^2.0.7"
-imagesize = "^1.4.1"
-pillow = "^10.0.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.*"

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@ strict = true
 warn_return_any = false
 implicit_reexport = false
 namespace_packages = true
-plugins = numpy.typing.mypy_plugin
+plugins = numpy.typing.mypy_plugin, pydantic.mypy
 # Exclude all except content of defined dirs
 exclude = (?x)(^
         (?!

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,20 @@
+{
+    "include": [
+        "**/scripts",
+        "**/app",
+        "**/src",
+    ],
+    "exclude": [
+        "**/node_modules",
+        "**/.venv",
+        "**/.pytest_cache",
+        "**/__pycache__",
+        ".ruff_cache",
+        "**/Python.framework/**",
+    ],
+    "ignore": [
+        "backend/datascience"
+    ],
+    "typeCheckingMode": "strict",
+    "pythonVersion": "3.11"
+}


### PR DESCRIPTION
Since we are using a multi-root projects including their root foler as a project, Pylance analysis every files in the root folder, including .venv.
This created cases where Pylance would use 100% CPU without stoping, even when VSCode is killed. Hopefully, these changes will prevent Pylance for going into this unstable state.

pyrightconfig.json contains configurations used by Pylance. It includes our working folders and excludes unnecessary folders.

In addition, obsolete mypy configuration in datascience/pyproject.toml are moved to mypy.ini.

Closes: #100

Testing proof : 
![image](https://github.com/JoffreyLGT/e-commerce-mlops/assets/25529092/98448108-8fe4-425c-8ea6-7fbb91bcb72c)
