### PR TITLE
refactor(datascience): train_image_model now uses a flat images dir

### DIFF
--- a/datascience/scripts/train_image_model.py
+++ b/datascience/scripts/train_image_model.py
@@ -1,9 +1,6 @@
 # type: ignore
 """Train image model, evaluate its performance and generates figures and stats.
 
-from shutil import ignore_patterns
-
-
 All logs and best checkpoints are stored in --output-dir.
 --input-dir expects a dataset with this structure is expected:
 
@@ -12,42 +9,50 @@ dataset_dir
 ├── X_train.csv
 ├── images
 │   ├── test
-│   │   └── 2705 # One folder per category id
-│   │       └── image_977803476_product_278535420.jpg
+│   │   └── image_977803476_product_278535420.jpg
 │   └── train
-│       └── 2583 # One folder per category id
-│           └── image_1174586892_product_2940638801.jpg
+│       └── image_1174586892_product_2940638801.jpg
 ├── y_test.csv
 └── y_train.csv
 
 Use scripts/optimize_images.py to generate a dataset.
 """
-import itertools
 import logging
 import os
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
+import keras
 import numpy as np
 import pandas as pd
 import pydantic
 import pydantic_argparse
 import tensorflow as tf
-from pydantic import BaseModel, DirectoryPath
-from sklearn import metrics
-from tensorflow.keras import Sequential, layers  # pyright: ignore
-from tensorflow.keras.callbacks import (  # pyright: ignore
+from keras import Sequential, layers
+from keras.callbacks import (
     CSVLogger,
     EarlyStopping,
     ModelCheckpoint,
     TensorBoard,
 )
-from tensorflow.keras.losses import CategoricalCrossentropy  # pyright: ignore
-from tensorflow.keras.optimizers import SGD  # pyright: ignore
-from tensorflow.train import latest_checkpoint  # pyright: ignore
+from keras.losses import CategoricalCrossentropy
+from keras.optimizers import SGD
+from pydantic import BaseModel, DirectoryPath
+from sklearn import metrics
+from tensorflow.train import latest_checkpoint
 
 from src.core.settings import get_mobilenet_image_model_settings
+from src.utilities.dataset_utils import (
+    get_imgs_filenames,
+    to_img_feature_target,
+    to_normal_category_id,
+    to_simplified_category_id,
+)
+from src.utilities.model_eval import (
+    gen_classification_report,
+    gen_confusion_matrix,
+    gen_training_history_figure,
+)
 
 
 class TrainImageModelArgs(BaseModel):
@@ -107,36 +112,63 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
     # Especially annoying with tensorflow-metal
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
-    model_settings = get_mobilenet_image_model_settings()
+    logger.info("Load data")
+
+    df_X_train = pd.read_csv(args.input_dir / "X_train.csv", index_col=0).fillna("")
+    df_X_test = pd.read_csv(args.input_dir / "X_test.csv", index_col=0).fillna("")
+
+    logger.info("Extract features and target")
+    X_train = get_imgs_filenames(
+        df_X_train["productid"].to_list(),
+        df_X_train["imageid"].to_list(),
+        args.input_dir / "images",
+    )
+    X_test = get_imgs_filenames(
+        df_X_test["productid"].to_list(),
+        df_X_test["imageid"].to_list(),
+        args.input_dir / "images",
+    )
+
+    y_train = np.loadtxt(
+        args.input_dir / "y_train.csv",
+        dtype=int,
+        delimiter=",",
+        skiprows=1,
+        usecols=(1),
+    )
+    y_test = np.loadtxt(
+        args.input_dir / "y_test.csv", dtype=int, delimiter=",", skiprows=1, usecols=(1)
+    )
+
+    y_train_simplified = to_simplified_category_id(y_train)
+    y_test_simplified = to_simplified_category_id(y_test)
+
+    y_train_categorical = keras.utils.to_categorical(y_train_simplified)
+    y_test_categorical = keras.utils.to_categorical(y_test_simplified)
 
     logger.info("Create datasets")
-
-    train_dir = args.input_dir / "images" / "train"
-    test_dir = args.input_dir / "images" / "test"
-    (train_ds, val_ds) = tf.keras.utils.image_dataset_from_directory(
-        train_dir,
-        validation_split=0.2,
-        subset="both",
-        seed=args.seed,
-        image_size=(model_settings.IMG_WIDTH, model_settings.IMG_HEIGHT),
-        batch_size=args.batch_size,
-        label_mode="categorical",
+    train_ds = (
+        tf.data.Dataset.from_tensor_slices((X_train, y_train_categorical))
+        .map(to_img_feature_target)
+        .batch(args.batch_size)
     )
 
-    nb_train_images = len(train_ds.file_paths)
-    nb_val_images = len(val_ds.file_paths)
-
-    test_ds = tf.keras.utils.image_dataset_from_directory(
-        test_dir,
-        image_size=(model_settings.IMG_WIDTH, model_settings.IMG_HEIGHT),
-        batch_size=args.batch_size,
-        label_mode="categorical",
+    test_ds = (
+        tf.data.Dataset.from_tensor_slices((X_test, y_test_categorical))
+        .map(to_img_feature_target)
+        .batch(args.batch_size)
     )
+
+    model_settings = get_mobilenet_image_model_settings()
+
+    nb_train_images = len(X_train)
+    nb_test_images = len(X_test)
+
     # Add cache configuration to speed up training
     # If this cause issues, we'll add an argument to enable it
     autotune = tf.data.AUTOTUNE
     train_ds = train_ds.cache().prefetch(buffer_size=autotune)
-    val_ds = val_ds.cache().prefetch(buffer_size=autotune)
+    test_ds = test_ds.cache().prefetch(buffer_size=autotune)
 
     logger.info("Build image model")
     mobilenet_layers = tf.keras.applications.MobileNetV2(
@@ -221,19 +253,19 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
         # Insert the metrics into a CSV file
         CSVLogger(history_file_path, separator=",", append=True),
         # Log information to display them in TensorBoard
-        TensorBoard(log_dir=tensorboard_logs_dir, histogram_freq=1),
+        TensorBoard(log_dir=str(tensorboard_logs_dir), histogram_freq=1),
     ]
 
     logger.info("Start model training")
     steps_per_epoch = nb_train_images // args.batch_size
-    validation_steps = nb_val_images // args.batch_size
+    validation_steps = nb_test_images // args.batch_size
 
     # Train the top layer
     model.fit(
         train_ds.repeat(),
         epochs=100,
         steps_per_epoch=steps_per_epoch,
-        validation_data=val_ds.repeat(),
+        validation_data=test_ds.repeat(),
         validation_steps=validation_steps,
         callbacks=cp_callbacks,
     )
@@ -247,7 +279,7 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
     mobilenet_layers.trainable = True
     model.compile(
         optimizer=SGD(learning_rate=0.001, momentum=0.9),
-        loss=CategoricalCrossentropy(from_logits=True, label_smoothing=0.1),
+        loss=CategoricalCrossentropy(label_smoothing=0.1),
         metrics=["accuracy"],
     )
     model.summary()
@@ -255,7 +287,7 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
         train_ds.repeat(),
         epochs=100,
         steps_per_epoch=steps_per_epoch,
-        validation_data=val_ds.repeat(),
+        validation_data=test_ds.repeat(),
         validation_steps=validation_steps,
         callbacks=cp_callbacks,
     )
@@ -267,124 +299,24 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
         model.load_weights(latest)
     model.save(args.output_dir / "cnn_mobilenetv2.keras")
 
-    # TODO @joffreylgt: figure and stats generation should be in their own functions.
-    #  https://github.com/JoffreyLGT/e-commerce-mlops/issues/103
-
     logger.info("Generate training history figure")
-    training_history = pd.read_csv(history_file_path, delimiter=",", header=0)
+    logger.info(gen_training_history_figure(history_file_path, args.output_dir))
 
-    fig = plt.figure(figsize=(10, 3))
-    ax1 = fig.add_subplot(121)
+    logger.info("Predict test data categories")
+    y_pred_simplified = model.predict(test_ds)
+    y_pred = to_normal_category_id([np.argmax(i) for i in y_pred_simplified])
 
-    # TODO @joffreylgt: translate from French to English.
-    #  https://github.com/JoffreyLGT/e-commerce-mlops/issues/103
+    logger.info(f"Accuracy score: {metrics.accuracy_score(y_test, y_pred)}")
 
-    # Labels des axes
-    ax1.set_xlabel("Epochs")
-    ax1.set_ylabel("Accuracy")
-
-    # Courbe de la précision sur l'échantillon d'entrainement
-    ax1.plot(
-        np.arange(1, training_history["accuracy"].count() + 1, 1),
-        training_history["accuracy"],
-        label="Training Accuracy",
-        color="blue",
-    )
-
-    # Courbe de la précision sur l'échantillon de test
-    ax1.plot(
-        np.arange(1, training_history["val_accuracy"].count() + 1, 1),
-        training_history["val_accuracy"],
-        label="Validation Accuracy",
-        color="red",
-    )
-
-    ax1.legend()
-    ax1.set_title("Accuracy per epoch")
-
-    ax2 = fig.add_subplot(122)
-    ax2.set_ylabel("Loss")
-    ax2.set_xlabel("Epochs")
-
-    ax2.plot(
-        np.arange(1, training_history["loss"].count() + 1, 1),
-        training_history["loss"],
-        label="Training loss",
-        linestyle="dashed",
-        color="blue",
-    )
-
-    ax2.plot(
-        np.arange(1, training_history["val_loss"].count() + 1, 1),
-        training_history["val_loss"],
-        label="Validation loss",
-        linestyle="dashed",
-        color="red",
-    )
-
-    ax2.legend()
-    ax2.set_title("Loss per epoch")
-
-    plt.savefig(args.output_dir / "training_history.png")
-
-    logger.info("Predict category on test data")
-
-    predictions = np.array([])
-    labels = np.array([])
-    for x, y in test_ds:
-        predictions = np.concatenate(
-            [predictions, np.argmax(model.predict(x, verbose=0), axis=-1)]
-        )
-        labels = np.concatenate([labels, np.argmax(y.numpy(), axis=-1)])
-
-    prdtypecodes = sorted([int(x) for x in os.listdir(test_dir)])
-
-    test_labels = [prdtypecodes[int(i)] for i in labels]
-    predictions_labels = [prdtypecodes[int(i)] for i in predictions]
-
-    logger.info(
-        f"Accuracy score: {metrics.accuracy_score(test_labels, predictions_labels)}"
-    )
     logger.info("Generate classification report")
-    class_report = metrics.classification_report(
-        test_labels, predictions_labels, zero_division=0.0  # pyright: ignore
-    )
-
-    Path(args.output_dir / "classification_report.txt").write_text(str(class_report))
-    logger.info(str(class_report))
+    (_, class_report) = gen_classification_report(y_test, y_pred, args.output_dir)
+    logger.info(class_report)
 
     logger.info("Generate confusion matrix")
-    cnf_matrix = np.round(
-        metrics.confusion_matrix(test_labels, predictions_labels, normalize="true"), 2
-    )
-
-    classes = range(0, nb_output_classes)
-
-    plt.figure(figsize=(13, 13))
-
-    plt.imshow(cnf_matrix, interpolation="nearest", cmap="Blues")
-    plt.title("Matrice de confusion")
-    tick_marks = classes
-    plt.xticks(tick_marks, prdtypecodes)
-    plt.yticks(tick_marks, prdtypecodes)
-
-    for i, j in itertools.product(
-        range(cnf_matrix.shape[0]), range(cnf_matrix.shape[1])
-    ):
-        plt.text(
-            j,
-            i,
-            cnf_matrix[i, j],
-            horizontalalignment="center",
-            color="white" if cnf_matrix[i, j] > (cnf_matrix.max() / 2) else "black",
-        )
-
-    plt.ylabel("Vrais labels")
-    plt.xlabel("Labels prédits")
-    plt.xticks(rotation=45)
-    plt.savefig(args.output_dir / "confusion_matrix.png")
+    logger.info(gen_confusion_matrix(y_test, y_pred, args.output_dir))
 
     logger.info("Script finished")
+
     return 0
 
 

--- a/datascience/src/utilities/model_eval.py
+++ b/datascience/src/utilities/model_eval.py
@@ -1,0 +1,150 @@
+"""Utility functions to evaluate models performance and generate figures."""
+import itertools
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from pydantic import DirectoryPath, FilePath
+from sklearn import metrics
+
+from src.core.settings import get_common_settings
+
+
+def gen_training_history_figure(
+    history_file_path: FilePath, output_dir: DirectoryPath
+) -> Path:
+    """Generate a figure with training history data.
+
+    One subfigure shows training and validation accuracy.
+    A second subfigure shows training and validation loss.
+
+    Args:
+        history_file_path: path to the csv containing training history.
+        output_dir: directory to save the figure in.
+
+    Returns:
+        Path to the generated figure.
+    """
+    training_history = pd.read_csv(history_file_path, delimiter=",", header=0)
+
+    fig = plt.figure(figsize=(10, 3))
+    ax1 = fig.add_subplot(121)
+
+    ax1.set_xlabel("Epochs")
+    ax1.set_ylabel("Accuracy")
+
+    ax1.plot(
+        np.arange(1, training_history["accuracy"].count() + 1, 1),
+        training_history["accuracy"],
+        label="Training Accuracy",
+        color="blue",
+    )
+
+    ax1.plot(
+        np.arange(1, training_history["val_accuracy"].count() + 1, 1),
+        training_history["val_accuracy"],
+        label="Validation Accuracy",
+        color="red",
+    )
+
+    ax1.legend()
+    ax1.set_title("Accuracy per epoch")
+
+    ax2 = fig.add_subplot(122)
+    ax2.set_ylabel("Loss")
+    ax2.set_xlabel("Epochs")
+
+    ax2.plot(
+        np.arange(1, training_history["loss"].count() + 1, 1),
+        training_history["loss"],
+        label="Training loss",
+        linestyle="dashed",
+        color="blue",
+    )
+
+    ax2.plot(
+        np.arange(1, training_history["val_loss"].count() + 1, 1),
+        training_history["val_loss"],
+        label="Validation loss",
+        linestyle="dashed",
+        color="red",
+    )
+
+    ax2.legend()
+    ax2.set_title("Loss per epoch")
+    file_path = output_dir / "training_history.png"
+    plt.savefig(file_path)
+    return file_path
+
+
+def gen_classification_report(
+    y: np.ndarray[Any, np.dtype[np.int32]],
+    y_pred: np.ndarray[Any, np.dtype[np.int32]],
+    output_dir: DirectoryPath,
+) -> tuple[Path, str]:
+    """Generate a classification report and save it into a txt file.
+
+    Args:
+        y: target values.
+        y_pred: predicted values.
+        output_dir: directory to save the txt file in.
+
+    Returns:
+        A tuple with (path to savex txt file, classification report).
+    """
+    class_report = str(
+        metrics.classification_report(y, y_pred, zero_division=0.0)  # pyright: ignore
+    )
+    file_path = output_dir / "classification_report.txt"
+    file_path.write_text(class_report)
+    return (file_path, class_report)
+
+
+def gen_confusion_matrix(
+    y: np.ndarray[Any, np.dtype[np.int32]],
+    y_pred: np.ndarray[Any, np.dtype[np.int32]],
+    output_dir: DirectoryPath,
+) -> Path:
+    """Generate a confusion matrix and save the figure.
+
+    Args:
+        y: target values.
+        y_pred: predicted values.
+        output_dir: directory to save the txt file in.
+
+    Returns:
+        Path to the generated figure.
+    """
+    cnf_matrix = np.round(metrics.confusion_matrix(y, y_pred, normalize="true"), 2)
+
+    settings = get_common_settings()
+    classes = range(0, len(settings.CATEGORIES_DIC.keys()))
+    category_ids = list(settings.CATEGORIES_DIC.keys())
+
+    plt.figure(figsize=(13, 13))
+
+    plt.imshow(cnf_matrix, interpolation="nearest", cmap="Blues")
+    plt.title("Confusion matrix")
+    tick_marks = classes
+    plt.xticks(tick_marks, category_ids)
+    plt.yticks(tick_marks, category_ids)
+
+    for i, j in itertools.product(
+        range(cnf_matrix.shape[0]), range(cnf_matrix.shape[1])
+    ):
+        plt.text(
+            j,
+            i,
+            cnf_matrix[i, j],
+            horizontalalignment="center",
+            color="white" if cnf_matrix[i, j] > (cnf_matrix.max() / 2) else "black",
+        )
+
+    plt.ylabel("Real")
+    plt.xlabel("Predicted")
+    plt.xticks(rotation=45)
+    file_path = output_dir / "confusion_matrix.png"
+    plt.savefig(file_path)
+    return file_path

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,6 +36,7 @@ fixable = ["ALL"]
 # Rules to concider non-autofix-able
 unfixable = [
   "ERA001", # commented-out-code
+  "F841",   # unused-variable
 ]
 # pyproject.toml must be included to load configuration
 include = ["app/*.py", "scripts/*.py", "**/pyproject.toml", "src/*.py"]


### PR DESCRIPTION
Model evaluation is now done in separated function. Most of the code is close to text model to ensure easy maintainability.

Refs: #96, #103

# Proof of testing

```txt
❯ python -m scripts.train_image_model --input-dir "data/datasets/fusion_model" --output-dir "data/models/image/" --train-patience 2 &> image_training_log.txt

Script started
Load data
Extract features and target
Create datasets
Build image model
WARNING in optimizer.__init__, line 70: At this time, the v2.11+ optimizer `tf.keras.optimizers.SGD` runs slowly on M1/M2 Macs, please use the legacy Keras optimizer instead, located at `tf.keras.optimizers.legacy.SGD`.
WARNING in __init__.get, line 292: There is a known slowdown when using v2.11+ Keras optimizers on M1/M2 Macs. Falling back to the legacy Keras optimizer, i.e., `tf.keras.optimizers.legacy.SGD`.
Model: "RakutenImageNet"
_________________________________________________________________
 Layer (type)                Output Shape              Param #   
=================================================================
 Input (InputLayer)          [(None, 224, 224, 3)]     0         
                                                                 
 Augmentations (Sequential)  (None, 224, 224, 3)       0         
                                                                 
 Rescaling (Rescaling)       (None, 224, 224, 3)       0         
                                                                 
 mobilenetv2_1.00_224 (Func  (None, 7, 7, 1280)        2257984   
 tional)                                                         
                                                                 
 global_average_pooling2d (  (None, 1280)              0         
 GlobalAveragePooling2D)                                         
                                                                 
 Dropout (Dropout)           (None, 1280)              0         
                                                                 
 Output (Dense)              (None, 27)                34587     
                                                                 
=================================================================
Total params: 2292571 (8.75 MB)
Trainable params: 34587 (135.11 KB)
Non-trainable params: 2257984 (8.61 MB)
_________________________________________________________________
No checkpoint to load
Start model training
Epoch 1/100

Epoch 1: val_accuracy improved from -inf to 0.09115, saving model to data/models/image/checkpoints/cp_loss-3.36_acc-0.09.ckpt
8/8 - 7s - loss: 3.6398 - accuracy: 0.0703 - val_loss: 3.3623 - val_accuracy: 0.0911 - 7s/epoch - 840ms/step

Epoch 2/100

Epoch 2: val_accuracy improved from 0.09115 to 0.16146, saving model to data/models/image/checkpoints/cp_loss-3.13_acc-0.16.ckpt
8/8 - 6s - loss: 3.3559 - accuracy: 0.1355 - val_loss: 3.1303 - val_accuracy: 0.1615 - 6s/epoch - 808ms/step

Epoch 3/100

Epoch 3: val_accuracy improved from 0.16146 to 0.21354, saving model to data/models/image/checkpoints/cp_loss-2.94_acc-0.21.ckpt
8/8 - 5s - loss: 3.0130 - accuracy: 0.1873 - val_loss: 2.9449 - val_accuracy: 0.2135 - 5s/epoch - 672ms/step

Epoch 4/100

Epoch 4: val_accuracy improved from 0.21354 to 0.26042, saving model to data/models/image/checkpoints/cp_loss-2.82_acc-0.26.ckpt
8/8 - 5s - loss: 2.8124 - accuracy: 0.2497 - val_loss: 2.8198 - val_accuracy: 0.2604 - 5s/epoch - 662ms/step

Epoch 5/100

Epoch 5: val_accuracy improved from 0.26042 to 0.28125, saving model to data/models/image/checkpoints/cp_loss-2.73_acc-0.28.ckpt
8/8 - 5s - loss: 2.6120 - accuracy: 0.3068 - val_loss: 2.7292 - val_accuracy: 0.2812 - 5s/epoch - 664ms/step

Epoch 6/100

Epoch 6: val_accuracy improved from 0.28125 to 0.29948, saving model to data/models/image/checkpoints/cp_loss-2.68_acc-0.30.ckpt
8/8 - 5s - loss: 2.4835 - accuracy: 0.3546 - val_loss: 2.6764 - val_accuracy: 0.2995 - 5s/epoch - 679ms/step

Epoch 7/100

Epoch 7: val_accuracy improved from 0.29948 to 0.31510, saving model to data/models/image/checkpoints/cp_loss-2.64_acc-0.32.ckpt
8/8 - 5s - loss: 2.3285 - accuracy: 0.3891 - val_loss: 2.6409 - val_accuracy: 0.3151 - 5s/epoch - 664ms/step

Epoch 8/100

Epoch 8: val_accuracy improved from 0.31510 to 0.32422, saving model to data/models/image/checkpoints/cp_loss-2.61_acc-0.32.ckpt
8/8 - 5s - loss: 2.2807 - accuracy: 0.4143 - val_loss: 2.6101 - val_accuracy: 0.3242 - 5s/epoch - 660ms/step

Epoch 9/100

Epoch 9: val_accuracy did not improve from 0.32422
8/8 - 5s - loss: 2.1467 - accuracy: 0.4622 - val_loss: 2.5927 - val_accuracy: 0.3229 - 5s/epoch - 665ms/step

Epoch 10/100

Epoch 10: val_accuracy improved from 0.32422 to 0.33594, saving model to data/models/image/checkpoints/cp_loss-2.57_acc-0.34.ckpt
8/8 - 5s - loss: 2.0943 - accuracy: 0.4818 - val_loss: 2.5714 - val_accuracy: 0.3359 - 5s/epoch - 669ms/step

Epoch 11/100

Epoch 11: val_accuracy improved from 0.33594 to 0.33854, saving model to data/models/image/checkpoints/cp_loss-2.56_acc-0.34.ckpt
8/8 - 5s - loss: 2.0355 - accuracy: 0.5007 - val_loss: 2.5559 - val_accuracy: 0.3385 - 5s/epoch - 683ms/step

Epoch 12/100

Epoch 12: val_accuracy did not improve from 0.33854
8/8 - 5s - loss: 1.9895 - accuracy: 0.4980 - val_loss: 2.5462 - val_accuracy: 0.3346 - 5s/epoch - 638ms/step

Epoch 13/100

Epoch 13: val_accuracy did not improve from 0.33854
8/8 - 5s - loss: 1.9163 - accuracy: 0.5365 - val_loss: 2.5364 - val_accuracy: 0.3372 - 5s/epoch - 642ms/step

Start model fine tuning
WARNING in optimizer.__init__, line 70: At this time, the v2.11+ optimizer `tf.keras.optimizers.SGD` runs slowly on M1/M2 Macs, please use the legacy Keras optimizer instead, located at `tf.keras.optimizers.legacy.SGD`.
WARNING in __init__.get, line 292: There is a known slowdown when using v2.11+ Keras optimizers on M1/M2 Macs. Falling back to the legacy Keras optimizer, i.e., `tf.keras.optimizers.legacy.SGD`.
Model: "RakutenImageNet"
_________________________________________________________________
 Layer (type)                Output Shape              Param #   
=================================================================
 Input (InputLayer)          [(None, 224, 224, 3)]     0         
                                                                 
 Augmentations (Sequential)  (None, 224, 224, 3)       0         
                                                                 
 Rescaling (Rescaling)       (None, 224, 224, 3)       0         
                                                                 
 mobilenetv2_1.00_224 (Func  (None, 7, 7, 1280)        2257984   
 tional)                                                         
                                                                 
 global_average_pooling2d (  (None, 1280)              0         
 GlobalAveragePooling2D)                                         
                                                                 
 Dropout (Dropout)           (None, 1280)              0         
                                                                 
 Output (Dense)              (None, 27)                34587     
                                                                 
=================================================================
Total params: 2292571 (8.75 MB)
Trainable params: 2258459 (8.62 MB)
Non-trainable params: 34112 (133.25 KB)
_________________________________________________________________
Epoch 1/100

Epoch 1: val_accuracy did not improve from 0.33854
8/8 - 12s - loss: 8.7189 - accuracy: 0.1510 - val_loss: 10.9905 - val_accuracy: 0.0299 - 12s/epoch - 1s/step

Epoch 2/100

Epoch 2: val_accuracy did not improve from 0.33854
8/8 - 11s - loss: 8.3005 - accuracy: 0.0465 - val_loss: 9.8111 - val_accuracy: 0.0573 - 11s/epoch - 1s/step

Epoch 3/100

Epoch 3: val_accuracy did not improve from 0.33854
8/8 - 10s - loss: 8.1346 - accuracy: 0.0598 - val_loss: 5.7815 - val_accuracy: 0.0573 - 10s/epoch - 1s/step

Epoch 4/100

Epoch 4: val_accuracy did not improve from 0.33854
8/8 - 10s - loss: 8.8905 - accuracy: 0.0491 - val_loss: 10.3366 - val_accuracy: 0.0091 - 10s/epoch - 1s/step

Save the model
Generate training history figure
data/models/image/training_history.png
Predict test data categories
9/9 - 2s - 2s/epoch - 274ms/step

Accuracy score: 0.3376470588235294
Generate classification report
              precision    recall  f1-score   support

          10       0.17      0.16      0.17        31
          40       0.27      0.16      0.20        25
          50       0.33      0.12      0.17        17
          60       0.00      0.00      0.00         8
        1140       0.17      0.04      0.06        27
        1160       0.42      0.77      0.54        39
        1180       0.00      0.00      0.00         8
        1280       0.33      0.41      0.36        49
        1281       0.04      0.05      0.04        21
        1300       0.39      0.38      0.38        50
        1301       0.00      0.00      0.00         8
        1302       0.05      0.04      0.04        25
        1320       0.35      0.22      0.27        32
        1560       0.35      0.31      0.33        51
        1920       0.57      0.58      0.57        43
        1940       0.00      0.00      0.00         8
        2060       0.17      0.12      0.14        50
        2220       0.00      0.00      0.00         8
        2280       0.39      0.46      0.42        48
        2403       0.36      0.42      0.39        48
        2462       0.50      0.07      0.12        14
        2522       0.38      0.42      0.40        50
        2582       0.15      0.19      0.17        26
        2583       0.40      0.68      0.50       102
        2585       0.09      0.04      0.06        25
        2705       0.36      0.32      0.34        28
        2905       0.67      0.22      0.33         9

    accuracy                           0.34       850
   macro avg       0.26      0.23      0.22       850
weighted avg       0.31      0.34      0.31       850

Generate confusion matrix
data/models/image/confusion_matrix.png
Script finished

```