### PR TITLE
feat(datascience): add fusion model training script

### DIFF
--- a/datascience/scripts/train_fusion_model.py
+++ b/datascience/scripts/train_fusion_model.py
@@ -1,0 +1,348 @@
+# type: ignore
+"""Train fusion model, evaluate its performance and generates figures and stats.
+
+Training is done using results from both text and image models without their
+classification layer.
+
+All logs and best checkpoints are stored in --output-dir.
+--input-dir expects a dataset with this structure is expected:
+
+dataset_dir
+├── X_test.csv
+├── X_train.csv
+├── images
+│   ├── test
+│   │   └── image_977803476_product_278535420.jpg
+│   └── train
+│       └── image_1174586892_product_2940638801.jpg
+├── y_test.csv
+└── y_train.csv
+
+Use scripts/optimize_images.py to generate a dataset.
+"""
+import logging
+import os
+import pickle
+import sys
+from pathlib import Path, PurePath
+
+import keras
+import numpy as np
+import pandas as pd
+import pydantic
+import pydantic_argparse
+import tensorflow as tf
+from keras import layers
+from keras.callbacks import (
+    CSVLogger,
+    EarlyStopping,
+    ModelCheckpoint,
+    TensorBoard,
+)
+from keras.losses import CategoricalCrossentropy
+from keras.optimizers import SGD
+from pydantic import BaseModel, DirectoryPath, FilePath, validator
+from sklearn import metrics
+from tensorflow.train import latest_checkpoint
+
+from src.core.settings import get_common_settings
+from src.utilities.dataset_utils import (
+    get_imgs_filenames,
+    to_img_feature_target,
+    to_normal_category_id,
+    to_simplified_category_id,  # pyright: ignore
+)
+from src.utilities.model_eval import (
+    gen_classification_report,
+    gen_confusion_matrix,
+    gen_training_history_figure,
+)
+
+logger = logging.getLogger(__file__)
+
+
+def check_extension(file_path: FilePath) -> FilePath:
+    """Check file extension to ensure it's .h5 or .keras.
+
+    Args:
+        file_path: path to the model file.
+
+    Returns:
+        Path to the file if the format is correct.
+
+    Raises:
+        ValueError: when the file extension is incorrect.
+    """
+    if PurePath(file_path).suffix in [".h5", ".keras"]:
+        return file_path
+    raise ValueError("Only .h5 and .keras extensions are supported")  # noqa: TRY003
+
+
+class TrainFusionModelArgs(BaseModel):
+    """Hold all scripts arguments and do type checking."""
+
+    input_dir: DirectoryPath = pydantic.Field(
+        description="Directory containing the datasets to use."
+    )
+    output_dir: Path = pydantic.Field(
+        description="Directory to save trained model and stats."
+    )
+    text_model: FilePath = pydantic.Field(
+        description="Path to the saved text model. Format must be either .h5 or .keras."
+    )
+    _check_text_model_extension = validator("text_model", allow_reuse=True)(
+        check_extension
+    )
+    text_preprocessor: FilePath = pydantic.Field(
+        description="Path to the text preprocessor pkl."
+    )
+    image_model: FilePath = pydantic.Field(
+        description=(
+            "Path to the saved image model. Format must be either .h5 or .keras."
+        )
+    )
+    _check_image_model_extension = validator("image_model", allow_reuse=True)(
+        check_extension
+    )
+
+    batch_size: int = pydantic.Field(
+        96,
+        description=(
+            "Size of the batches to use for the training. "
+            "Set as much as your machine allows."
+        ),
+    )
+    train_patience: int = pydantic.Field(
+        10,
+        description=(
+            "Number of epoch to do without improvements "
+            "before stopping the model training."
+        ),
+    )
+
+
+def main(args: TrainFusionModelArgs) -> int:  # noqa: PLR0915
+    """Create and train a new fusion model.
+
+    All artifacts are exported into output-dir.
+
+    Args:
+        args: arguments provided when calling the script.
+
+    Return:
+        0 if everything went as expected, 1 otherwise.
+    """
+    logger.info("Script started")
+
+    # Ensure all messages from Tensorflow will be logged and not only printed
+    tf.keras.utils.disable_interactive_logging()
+    # Avoid Tensorflow flooding the console with messages
+    # Especially annoying with tensorflow-metal
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+    logger.info("Load data")
+
+    df_X_train = pd.read_csv(args.input_dir / "X_train.csv", index_col=0).fillna("")
+    df_X_test = pd.read_csv(args.input_dir / "X_test.csv", index_col=0).fillna("")
+
+    logger.info("Extract features")
+    X_train_text = df_X_train["designation"] + " " + df_X_train["description"]
+    X_test_text = df_X_test["designation"] + " " + df_X_test["description"]
+    X_train_img = get_imgs_filenames(
+        df_X_train["productid"].to_list(),
+        df_X_train["imageid"].to_list(),
+        args.input_dir / "images",
+    )
+    X_test_img = get_imgs_filenames(
+        df_X_test["productid"].to_list(),
+        df_X_test["imageid"].to_list(),
+        args.input_dir / "images",
+    )
+
+    logger.info("Extract targets")
+    y_train = np.loadtxt(
+        args.input_dir / "y_train.csv",
+        dtype=int,
+        delimiter=",",
+        skiprows=1,
+        usecols=(1),
+    )
+    y_test = np.loadtxt(
+        args.input_dir / "y_test.csv", dtype=int, delimiter=",", skiprows=1, usecols=(1)
+    )
+
+    y_train_simplified = to_simplified_category_id(y_train)
+    y_test_simplified = to_simplified_category_id(y_test)
+
+    y_train_categorical = keras.utils.to_categorical(y_train_simplified)
+    y_test_categorical = keras.utils.to_categorical(y_test_simplified)
+
+    logger.info("Load text preprocessor and preprocess text features")
+    preprocessor = pickle.load(args.text_preprocessor.open("rb"))
+    X_train_text_tensor = preprocessor.transform(X_train_text)
+    X_test_text_tensor = preprocessor.transform(X_test_text)
+
+    logger.info("Create text datasets")
+    train_txt_ds = tf.data.Dataset.from_tensor_slices(
+        (X_train_text_tensor, y_train_categorical)
+    ).batch(args.batch_size)
+    test_txt_ds = tf.data.Dataset.from_tensor_slices(
+        (X_test_text_tensor, y_test_categorical)
+    ).batch(args.batch_size)
+
+    logger.info("Create image datasets")
+    train_img_ds = (
+        tf.data.Dataset.from_tensor_slices((X_train_img, y_train_categorical))
+        .map(to_img_feature_target)
+        .batch(args.batch_size)
+    )
+    test_img_ds = (
+        tf.data.Dataset.from_tensor_slices((X_test_img, y_test_categorical))
+        .map(to_img_feature_target)
+        .batch(args.batch_size)
+    )
+
+    # Add cache configuration to speed up training
+    # If this cause issues, we'll add an argument to enable it
+    autotune = tf.data.AUTOTUNE
+    train_txt_ds = train_txt_ds.cache().prefetch(buffer_size=autotune)
+    test_txt_ds = test_txt_ds.cache().prefetch(buffer_size=autotune)
+    train_img_ds = train_img_ds.cache().prefetch(buffer_size=autotune)
+    test_img_ds = test_img_ds.cache().prefetch(buffer_size=autotune)
+
+    logger.info("Load text model without classification layers")
+    text_model = tf.keras.models.load_model(args.text_model, compile=False)
+    headless_text_model = tf.keras.Model(
+        inputs=text_model.inputs, outputs=text_model.layers[-2].output
+    )
+    headless_text_model.summary()
+
+    logger.info("Load image model without classification layers")
+    image_model = tf.keras.models.load_model(args.image_model, compile=False)
+    headless_image_model = tf.keras.Model(
+        inputs=image_model.inputs, outputs=image_model.layers[-2].output
+    )
+    headless_image_model.summary()
+
+    logger.info("Predict using text model")
+    train_txt_output = headless_text_model.predict(train_txt_ds)
+    test_txt_output = headless_text_model.predict(test_txt_ds)
+
+    logger.info("Predict using image model")
+    train_img_output = headless_image_model.predict(train_img_ds)
+    test_img_output = headless_image_model.predict(test_img_ds)
+
+    logger.info("Create fusion model dataset")
+    train_fusion = np.concatenate((train_txt_output, train_img_output), axis=1)
+    test_fusion = np.concatenate((test_txt_output, test_img_output), axis=1)
+
+    train_fusion_ds = tf.data.Dataset.from_tensor_slices(
+        (train_fusion, y_train_categorical)
+    ).batch(args.batch_size)
+    test_fusion_ds = tf.data.Dataset.from_tensor_slices(
+        (test_fusion, y_test_categorical)
+    ).batch(args.batch_size)
+
+    checkpoints_dir = args.output_dir / "checkpoints"
+    checkpoint_file_path = (
+        checkpoints_dir / "cp_loss-{val_loss:.2f}_acc-{val_accuracy:.2f}.ckpt"
+    )
+    history_file_path = args.output_dir / "history.csv"
+    tensorboard_logs_dir = args.output_dir / "tensorboard_logs"
+
+    settings = get_common_settings()
+    fusion_model = tf.keras.Sequential()
+    fusion_model.add(layers.InputLayer(input_shape=(train_fusion.shape[1])))
+    fusion_model.add(layers.Dense(units=512, activation="relu"))
+    fusion_model.add(layers.Dropout(rate=0.2))
+
+    fusion_model.add(layers.Dense(units=128, activation="relu"))
+    fusion_model.add(layers.Dropout(rate=0.2))
+
+    fusion_model.add(
+        layers.Dense(
+            len(settings.CATEGORIES_DIC.keys()), activation="softmax", name="Output"
+        )
+    )
+
+    fusion_model.build((None, train_fusion.shape[1]))
+    fusion_model.compile(
+        optimizer=SGD(learning_rate=0.005, momentum=0.9),
+        loss=CategoricalCrossentropy(from_logits=True, label_smoothing=0.1),
+        metrics=["accuracy"],
+    )
+    fusion_model.summary()
+
+    latest = latest_checkpoint(checkpoints_dir)
+    if latest is not None:
+        logger.info(f"Load checkpoint: {latest}")
+        fusion_model.load_weights(latest)
+    else:
+        logger.info("No checkpoint to load")
+
+    # Callbacks called between each epoch
+    cp_callbacks = [
+        # Stop the training when there is no improvement in val_accuracy for x epochs
+        EarlyStopping(monitor="val_accuracy", patience=args.train_patience),
+        # Save a checkpoint
+        ModelCheckpoint(
+            checkpoint_file_path,
+            save_best_only=True,
+            mode="max",
+            monitor="val_accuracy",
+            save_weights_only=True,
+            verbose=1,
+        ),
+        # Insert the metrics into a CSV file
+        CSVLogger(history_file_path, separator=",", append=True),
+        # Log information to display them in TensorBoard
+        TensorBoard(log_dir=str(tensorboard_logs_dir), histogram_freq=1),
+    ]
+
+    logger.info("Start fusion model training")
+    fusion_model.fit(
+        train_fusion_ds,
+        epochs=100,
+        validation_data=test_fusion_ds,
+        callbacks=cp_callbacks,
+    )
+
+    logger.info("Save the fusion_model")
+    # Load the latest checkpoint to avoid overfitting
+    latest = latest_checkpoint(checkpoints_dir)
+    if latest is not None:
+        fusion_model.load_weights(latest)
+    fusion_model.save(args.output_dir / "fusion.keras")
+
+    logger.info("Generate training history figure")
+    logger.info(gen_training_history_figure(history_file_path, args.output_dir))
+
+    logger.info("Predict test data categories")
+    y_pred_simplified = fusion_model.predict(test_fusion_ds)
+    y_pred = to_normal_category_id([np.argmax(i) for i in y_pred_simplified])
+
+    logger.info(f"Accuracy score: {metrics.accuracy_score(y_test, y_pred)}")
+
+    logger.info("Generate classification report")
+    (_, class_report) = gen_classification_report(y_test, y_pred, args.output_dir)
+    logger.info(class_report)
+
+    logger.info("Generate confusion matrix")
+    logger.info(gen_confusion_matrix(y_test, y_pred, args.output_dir))
+
+    logger.info("Script finished")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = pydantic_argparse.ArgumentParser(
+        model=TrainFusionModelArgs,
+        description=(
+            "Create and train a new fusion model "
+            "using dataset provided with --input-dir, "
+            "then save it to --output-dir with "
+            "its performance statistics."
+        ),
+    )
+    args = parser.parse_typed_args()
+    sys.exit(main(args))

--- a/datascience/scripts/train_fusion_model.py
+++ b/datascience/scripts/train_fusion_model.py
@@ -133,6 +133,7 @@ def main(args: TrainFusionModelArgs) -> int:  # noqa: PLR0915
         0 if everything went as expected, 1 otherwise.
     """
     logger.info("Script started")
+    logger.info(f"Args: {args}")
 
     # Ensure all messages from Tensorflow will be logged and not only printed
     tf.keras.utils.disable_interactive_logging()

--- a/datascience/scripts/train_image_model.py
+++ b/datascience/scripts/train_image_model.py
@@ -41,7 +41,7 @@ from pydantic import BaseModel, DirectoryPath
 from sklearn import metrics
 from tensorflow.train import latest_checkpoint
 
-from src.core.settings import get_mobilenet_image_model_settings
+from src.core.settings import get_common_settings, get_mobilenet_image_model_settings
 from src.utilities.dataset_utils import (
     get_imgs_filenames,
     to_img_feature_target,
@@ -209,17 +209,14 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
     x = layers.GlobalAveragePooling2D()(x)
     x = layers.Dropout(rate=0.2, name="Dropout")(x)
 
-    # TODO @joffreylgt: set value in configuration
-    #  https://github.com/JoffreyLGT/e-commerce-mlops/issues/103
-    nb_output_classes = 27
-
     checkpoints_dir = args.output_dir / "checkpoints"
     checkpoint_file_path = (
         checkpoints_dir / "cp_loss-{val_loss:.2f}_acc-{val_accuracy:.2f}.ckpt"
     )
     history_file_path = args.output_dir / "history.csv"
     tensorboard_logs_dir = args.output_dir / "tensorboard_logs"
-    outputs = layers.Dense(nb_output_classes, name="Output")(x)
+    settings = get_common_settings()
+    outputs = layers.Dense(len(settings.CATEGORIES_DIC.keys()), name="Output")(x)
     model = tf.keras.Model(inputs, outputs, name="RakutenImageNet")
 
     model.build((None, model_settings.IMG_WIDTH, model_settings.IMG_HEIGHT, 3))

--- a/datascience/scripts/train_image_model.py
+++ b/datascience/scripts/train_image_model.py
@@ -105,6 +105,7 @@ def main(args: TrainImageModelArgs) -> int:  # noqa: PLR0915
     logger = logging.getLogger(__file__)
 
     logger.info("Script started")
+    logger.info(f"Args: {args}")
 
     # Ensure all messages from Tensorflow will be logged and not only printed
     tf.keras.utils.disable_interactive_logging()

--- a/datascience/scripts/train_text_model.py
+++ b/datascience/scripts/train_text_model.py
@@ -96,6 +96,7 @@ def main(args: TrainTextModelArgs) -> int:  # noqa: PLR0915
         0 if everything went as expected, 1 otherwise.
     """
     logger.info("Script started")
+    logger.info(f"Args: {args}")
 
     # Ensure all messages from Tensorflow will be logged and not only printed
     tf.keras.utils.disable_interactive_logging()

--- a/datascience/src/transformers/text_transformer.py
+++ b/datascience/src/transformers/text_transformer.py
@@ -1,0 +1,143 @@
+# type: ignore
+# ruff: noqa
+"""All classes and functions used to preprocess text data."""
+
+import logging
+import pickle
+import re
+from html.parser import HTMLParser
+
+import pandas as pd
+import tensorflow as tf
+from nltk.stem.snowball import SnowballStemmer
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.feature_extraction.text import (
+    CountVectorizer,
+    TfidfVectorizer,
+)
+from sklearn.pipeline import Pipeline
+
+from src.utilities.dataset_utils import convert_sparse_matrix_to_sparse_tensor
+
+logger = logging.getLogger(__file__)
+
+
+class TextPreprocess:
+    def __init__(self, pipeline) -> None:
+        self.pipeline = pipeline
+
+    def fit(self, data):
+        return self.pipeline.fit(data)
+
+    def fit_transform(self, data) -> tf.SparseTensor:
+        out = self.pipeline.fit_transform(data)
+        return convert_sparse_matrix_to_sparse_tensor(out)
+
+    def transform(self, data) -> tf.SparseTensor:
+        out = self.pipeline.transform(data)
+        return convert_sparse_matrix_to_sparse_tensor(out)
+
+    def get_voc(self):
+        return self.pipeline.get_voc()
+
+    def save_voc(self, prefix_filename):
+        voc = self.get_voc()
+        file_name = f"{prefix_filename}_{self.pipeline.name}.pkl"
+        with open(file_name, "wb") as fp:
+            pickle.dump(voc, fp)
+        logger.info(f"TextPreprocess.save_voc {file_name}")
+        return file_name
+
+
+class _RakutenHTMLParser(HTMLParser):
+    """Parse the textand return the content without HTML tag or encoding."""
+
+    def __init__(self):
+        self.allcontent = ""
+        super().__init__()
+
+    def handle_data(self, data):
+        self.allcontent += data + " "
+
+    def get_all_content(self):
+        return self.allcontent.strip()
+
+
+class HTMLRemover(BaseEstimator, TransformerMixin):
+    """Transformer removing HTML tags and decoding HTML special characters."""
+
+    def _parseValue(self, value):
+        if type(value) != str:
+            return value
+        parser = _RakutenHTMLParser()
+        parser.feed(value)
+        return parser.get_all_content()
+
+    def _parseColumn(self, column):
+        return [self._parseValue(value) for value in column]
+
+    def fit(self, X, y=None):
+        # Do nothing, mandatory function for when a model is provided to the pipeline.
+        return self
+
+    def transform(self, X):
+        if type(X) == pd.DataFrame:
+            return X.apply(lambda column: self._parseColumn(column))
+
+        return X.apply(lambda column: self._parseValue(column))
+
+
+class NumRemover(BaseEstimator, TransformerMixin):
+    """Remove all number from strings."""
+
+    def _parse_value(self, value):
+        if isinstance(type(value), int):
+            return value
+        return re.sub("\s?([0-9]+)\s?", " ", value)
+
+    def _parse_column(self, column):
+        return [self._parse_value(value) for value in column]
+
+    def fit(self, X, y=None):
+        # Do nothing, mandatory function for when a model is provided to the pipeline.
+        return self
+
+    def transform(self, X):
+        if type(X) == pd.DataFrame:
+            return X.apply(lambda column: self._parse_column(column))
+
+        return X.apply(lambda column: self._parse_value(column))
+
+
+class StemmedCountVectorizer(CountVectorizer):
+    fr_stemmer = SnowballStemmer("french")
+
+    def build_analyzer(self):
+        analyzer = super().build_analyzer()
+        return lambda doc: (
+            StemmedCountVectorizer.fr_stemmer.stem(w) for w in analyzer(doc)
+        )
+
+
+class StemmedTfidfVectorizer(TfidfVectorizer):
+    fr_stemmer = SnowballStemmer("french")
+
+    def build_analyzer(self):
+        analyzer = super().build_analyzer()
+        return lambda doc: (
+            StemmedTfidfVectorizer.fr_stemmer.stem(w) for w in analyzer(doc)
+        )
+
+
+class TfidfStemming(Pipeline):
+    def __init__(self) -> None:
+        self.name = "TfidfStemming"
+        steps = [
+            ("remove_html", HTMLRemover()),
+            ("remove_num", NumRemover()),
+            ("tfidStem", StemmedTfidfVectorizer()),
+        ]
+        Pipeline.__init__(self, steps)
+
+    def get_voc(self):
+        return self.steps[2][1].vocabulary_

--- a/datascience/src/utilities/dataset_utils.py
+++ b/datascience/src/utilities/dataset_utils.py
@@ -230,3 +230,10 @@ def to_img_feature_target(filename: str, y: Any) -> tuple[tf.Tensor, Any]:
     img = tf.io.read_file(filename)
     img = tf.io.decode_jpeg(img, channels=3)
     return (tf.image.resize(img, [224, 224]), y)
+
+
+def convert_sparse_matrix_to_sparse_tensor(X) -> tf.SparseTensor:
+    """Convert provided sparse matrix into a sparse tensor."""
+    coo = X.tocoo()
+    indices = np.mat([coo.row, coo.col]).transpose()
+    return tf.sparse.reorder(tf.SparseTensor(indices, coo.data, coo.shape))

--- a/datascience/src/utilities/dataset_utils.py
+++ b/datascience/src/utilities/dataset_utils.py
@@ -232,7 +232,7 @@ def to_img_feature_target(filename: str, y: Any) -> tuple[tf.Tensor, Any]:
     return (tf.image.resize(img, [224, 224]), y)
 
 
-def convert_sparse_matrix_to_sparse_tensor(X) -> tf.SparseTensor:
+def convert_sparse_matrix_to_sparse_tensor(X) -> tf.SparseTensor:  # type: ignore
     """Convert provided sparse matrix into a sparse tensor."""
     coo = X.tocoo()
     indices = np.mat([coo.row, coo.col]).transpose()


### PR DESCRIPTION
Closes #96
Refs #103 

# Proof of testing

```txt
❯ python -m scripts.train_fusion_model --train-patience 2 --input-dir "data/datasets/fusion_model" --output-dir "data/models/fusion" --text-model "data/models/text/mlp_text.keras" --text-preprocessor "data/models/text/text_preprocess.pkl" --image-model "data/models/image/cnn_mobilenetv2.keras" &> fusion_training_log.txt

Script started
Load data
Extract features
Extract targets
Load text preprocessor and preprocess text features
Create text datasets
Create image datasets
Load text model without classification layers
Model: "model"
_________________________________________________________________
 Layer (type)                Output Shape              Param #   
=================================================================
 input_1 (InputLayer)        [(None, 7868)]            0         
                                                                 
 dense (Dense)               (None, 128)               1007232   
                                                                 
 dropout (Dropout)           (None, 128)               0         
                                                                 
=================================================================
Total params: 1007232 (3.84 MB)
Trainable params: 1007232 (3.84 MB)
Non-trainable params: 0 (0.00 Byte)
_________________________________________________________________
Load image model without classification layers
Model: "model_1"
_________________________________________________________________
 Layer (type)                Output Shape              Param #   
=================================================================
 Input (InputLayer)          [(None, 224, 224, 3)]     0         
                                                                 
 Augmentations (Sequential)  (None, 224, 224, 3)       0         
                                                                 
 Rescaling (Rescaling)       (None, 224, 224, 3)       0         
                                                                 
 mobilenetv2_1.00_224 (Func  (None, 7, 7, 1280)        2257984   
 tional)                                                         
                                                                 
 global_average_pooling2d (  (None, 1280)              0         
 GlobalAveragePooling2D)                                         
                                                                 
 Dropout (Dropout)           (None, 1280)              0         
                                                                 
=================================================================
Total params: 2257984 (8.61 MB)
Trainable params: 2223872 (8.48 MB)
Non-trainable params: 34112 (133.25 KB)
_________________________________________________________________
Predict using text model
9/9 - 0s - 105ms/epoch - 12ms/step

9/9 - 0s - 64ms/epoch - 7ms/step

Predict using image model
9/9 - 2s - 2s/epoch - 269ms/step

9/9 - 2s - 2s/epoch - 277ms/step

Create fusion model dataset
WARNING in optimizer.__init__, line 70: At this time, the v2.11+ optimizer `tf.keras.optimizers.SGD` runs slowly on M1/M2 Macs, please use the legacy Keras optimizer instead, located at `tf.keras.optimizers.legacy.SGD`.
WARNING in __init__.get, line 292: There is a known slowdown when using v2.11+ Keras optimizers on M1/M2 Macs. Falling back to the legacy Keras optimizer, i.e., `tf.keras.optimizers.legacy.SGD`.
Model: "sequential"
_________________________________________________________________
 Layer (type)                Output Shape              Param #   
=================================================================
 dense (Dense)               (None, 512)               721408    
                                                                 
 dropout (Dropout)           (None, 512)               0         
                                                                 
 dense_1 (Dense)             (None, 128)               65664     
                                                                 
 dropout_1 (Dropout)         (None, 128)               0         
                                                                 
 Output (Dense)              (None, 27)                3483      
                                                                 
=================================================================
Total params: 790555 (3.02 MB)
Trainable params: 790555 (3.02 MB)
Non-trainable params: 0 (0.00 Byte)
_________________________________________________________________
No checkpoint to load
Start fusion model training
Epoch 1/100
/Users/joffrey/workspace/e-commerce-mlops/datascience/.venv/lib/python3.11/site-packages/keras/src/backend.py:5562: UserWarning: "`categorical_crossentropy` received `from_logits=True`, but the `output` argument was produced by a Softmax activation and thus does not represent logits. Was this intended?
  output, from_logits = _get_logits(

Epoch 1: val_accuracy improved from -inf to 0.14000, saving model to data/models/fusion/checkpoints/cp_loss-3.31_acc-0.14.ckpt
9/9 - 1s - loss: 3.9684 - accuracy: 0.0824 - val_loss: 3.3079 - val_accuracy: 0.1400 - 777ms/epoch - 86ms/step

Epoch 2/100

Epoch 2: val_accuracy improved from 0.14000 to 0.24000, saving model to data/models/fusion/checkpoints/cp_loss-2.97_acc-0.24.ckpt
9/9 - 0s - loss: 3.3306 - accuracy: 0.1731 - val_loss: 2.9692 - val_accuracy: 0.2400 - 237ms/epoch - 26ms/step

Epoch 3/100

Epoch 3: val_accuracy improved from 0.24000 to 0.30118, saving model to data/models/fusion/checkpoints/cp_loss-2.74_acc-0.30.ckpt
9/9 - 0s - loss: 2.8336 - accuracy: 0.2780 - val_loss: 2.7353 - val_accuracy: 0.3012 - 296ms/epoch - 33ms/step

Epoch 4/100

Epoch 4: val_accuracy improved from 0.30118 to 0.32235, saving model to data/models/fusion/checkpoints/cp_loss-2.63_acc-0.32.ckpt
9/9 - 0s - loss: 2.4883 - accuracy: 0.3675 - val_loss: 2.6271 - val_accuracy: 0.3224 - 205ms/epoch - 23ms/step

Epoch 5/100

Epoch 5: val_accuracy improved from 0.32235 to 0.34706, saving model to data/models/fusion/checkpoints/cp_loss-2.57_acc-0.35.ckpt
9/9 - 0s - loss: 2.2219 - accuracy: 0.4382 - val_loss: 2.5651 - val_accuracy: 0.3471 - 258ms/epoch - 29ms/step

Epoch 6/100

Epoch 6: val_accuracy improved from 0.34706 to 0.36235, saving model to data/models/fusion/checkpoints/cp_loss-2.52_acc-0.36.ckpt
9/9 - 0s - loss: 2.0113 - accuracy: 0.5206 - val_loss: 2.5244 - val_accuracy: 0.3624 - 199ms/epoch - 22ms/step

Epoch 7/100

Epoch 7: val_accuracy improved from 0.36235 to 0.37176, saving model to data/models/fusion/checkpoints/cp_loss-2.50_acc-0.37.ckpt
9/9 - 0s - loss: 1.8314 - accuracy: 0.5913 - val_loss: 2.4956 - val_accuracy: 0.3718 - 213ms/epoch - 24ms/step

Epoch 8/100

Epoch 8: val_accuracy improved from 0.37176 to 0.38000, saving model to data/models/fusion/checkpoints/cp_loss-2.47_acc-0.38.ckpt
9/9 - 0s - loss: 1.6760 - accuracy: 0.6572 - val_loss: 2.4740 - val_accuracy: 0.3800 - 223ms/epoch - 25ms/step

Epoch 9/100

Epoch 9: val_accuracy did not improve from 0.38000
9/9 - 0s - loss: 1.5405 - accuracy: 0.7150 - val_loss: 2.4583 - val_accuracy: 0.3800 - 172ms/epoch - 19ms/step

Epoch 10/100

Epoch 10: val_accuracy improved from 0.38000 to 0.38588, saving model to data/models/fusion/checkpoints/cp_loss-2.45_acc-0.39.ckpt
9/9 - 0s - loss: 1.4244 - accuracy: 0.7680 - val_loss: 2.4462 - val_accuracy: 0.3859 - 200ms/epoch - 22ms/step

Epoch 11/100

Epoch 11: val_accuracy improved from 0.38588 to 0.38941, saving model to data/models/fusion/checkpoints/cp_loss-2.44_acc-0.39.ckpt
9/9 - 0s - loss: 1.3228 - accuracy: 0.8210 - val_loss: 2.4376 - val_accuracy: 0.3894 - 202ms/epoch - 22ms/step

Epoch 12/100

Epoch 12: val_accuracy did not improve from 0.38941
9/9 - 0s - loss: 1.2363 - accuracy: 0.8598 - val_loss: 2.4314 - val_accuracy: 0.3882 - 167ms/epoch - 19ms/step

Epoch 13/100

Epoch 13: val_accuracy did not improve from 0.38941
9/9 - 0s - loss: 1.1621 - accuracy: 0.8940 - val_loss: 2.4257 - val_accuracy: 0.3882 - 165ms/epoch - 18ms/step

Save the fusion_model
Generate training history figure
data/models/fusion/training_history.png
Predict test data categories
9/9 - 0s - 41ms/epoch - 5ms/step

Accuracy score: 0.38941176470588235
Generate classification report
              precision    recall  f1-score   support

          10       0.36      0.32      0.34        31
          40       0.23      0.24      0.24        25
          50       0.00      0.00      0.00        17
          60       0.00      0.00      0.00         8
        1140       0.33      0.15      0.21        27
        1160       0.72      0.87      0.79        39
        1180       0.00      0.00      0.00         8
        1280       0.25      0.27      0.26        49
        1281       0.12      0.10      0.11        21
        1300       0.41      0.48      0.44        50
        1301       0.00      0.00      0.00         8
        1302       0.16      0.12      0.14        25
        1320       0.32      0.31      0.32        32
        1560       0.37      0.49      0.42        51
        1920       0.67      0.65      0.66        43
        1940       0.00      0.00      0.00         8
        2060       0.27      0.32      0.29        50
        2220       0.00      0.00      0.00         8
        2280       0.43      0.50      0.46        48
        2403       0.36      0.40      0.38        48
        2462       0.00      0.00      0.00        14
        2522       0.48      0.56      0.52        50
        2582       0.00      0.00      0.00        26
        2583       0.47      0.74      0.57       102
        2585       0.12      0.08      0.10        25
        2705       0.31      0.29      0.30        28
        2905       0.00      0.00      0.00         9

    accuracy                           0.39       850
   macro avg       0.24      0.25      0.24       850
weighted avg       0.34      0.39      0.36       850

Generate confusion matrix
data/models/fusion/confusion_matrix.png
Script finished
```